### PR TITLE
Fix some bugs for mDNSResponder-1790 on linux platform

### DIFF
--- a/mDNSCore/mDNS.c
+++ b/mDNSCore/mDNS.c
@@ -9849,7 +9849,7 @@ mDNSlocal void mDNSCoreReceiveNoUnicastAnswers(mDNS *const m, const DNSMessage *
 #else
                             const DNSServRef dnsserv = qptr->qDNSServer;
 #endif
-                            debugf("mDNSCoreReceiveNoUnicastAnswers making negative cache entry TTL %d for %##s (%s)", negttl, name->c, DNSTypeName(q.qtype));
+                            debugf("mDNSCoreReceiveNoUnicastAnswers making negative cache entry TTL %d for %##s (%s)", negttl, currentQName->c, DNSTypeName(q.qtype));
                             // Create a negative record for the current name in the CNAME chain.
                             MakeNegativeCacheRecord(m, &m->rec.r, currentQName, currentQNameHash, q.qtype, q.qclass, negttl, mDNSInterface_Any,
                                 dnsserv, response->h.flags);

--- a/mDNSCore/mDNSEmbeddedAPI.h
+++ b/mDNSCore/mDNSEmbeddedAPI.h
@@ -3037,6 +3037,7 @@ extern void mDNS_SetPrimaryInterfaceInfo(mDNS *m, const mDNSAddr *v4addr,  const
 extern DNSServer *mDNS_AddDNSServer(mDNS *const m, const domainname *d, const mDNSInterfaceID interface, mDNSs32 serviceID, const mDNSAddr *addr,
                                     const mDNSIPPort port, ScopeType scopeType, mDNSu32 timeout, mDNSBool cellIntf, mDNSBool isExpensive, mDNSBool isConstrained, mDNSBool isCLAT46,
                                     mDNSu32 resGroupID, mDNSBool reqA, mDNSBool reqAAAA, mDNSBool reqDO);
+extern void mDNS_ClearDNSServers(mDNS *const m);
 extern void PenalizeDNSServer(mDNS *const m, DNSQuestion *q, mDNSOpaque16 responseFlags);
 #endif
 extern void mDNS_AddSearchDomain(const domainname *const domain, mDNSInterfaceID InterfaceID);

--- a/mDNSCore/uDNS.c
+++ b/mDNSCore/uDNS.c
@@ -234,6 +234,20 @@ mDNSexport DNSServer *mDNS_AddDNSServer(mDNS *const m, const domainname *domain,
     return(server);
 }
 
+void mDNS_ClearDNSServers(mDNS *const m)
+{
+    mDNS_CheckLock(m);
+    DNSServer *p = m->DNSServers;
+    DNSServer *next = mDNSNULL;
+    while (p)
+    {
+        next = p->next;
+        mDNSPlatformMemFree(p);
+        p = next;
+    }
+    m->DNSServers = mDNSNULL;
+}
+
 // PenalizeDNSServer is called when the number of queries to the unicast
 // DNS server exceeds MAX_UCAST_UNANSWERED_QUERIES or when we receive an
 // error e.g., SERV_FAIL from DNS server.
@@ -7298,6 +7312,11 @@ mDNSexport DNSServer *mDNS_AddDNSServer(mDNS *const m, const domainname *d, cons
     (void) reqDO;
 
     return mDNSNULL;
+}
+
+void mDNS_ClearDNSServers(mDNS *const m)
+{
+    (void) m;
 }
 
 mDNSexport void uDNS_SetupWABQueries(mDNS *const m)

--- a/mDNSCore/uDNS.c
+++ b/mDNSCore/uDNS.c
@@ -7257,7 +7257,7 @@ mDNSexport mStatus mDNS_SetSecretForDomain(mDNS *m, DomainAuthInfo *info, const 
     return mStatus_UnsupportedErr;
 }
 
-mDNSexport domainname  *uDNS_GetNextSearchDomain(mDNSInterfaceID InterfaceID, mDNSs8 *searchIndex, mDNSBool ignoreDotLocal)
+mDNSexport domainname  *uDNS_GetNextSearchDomain(mDNSInterfaceID InterfaceID, int *searchIndex, mDNSBool ignoreDotLocal)
 {
     (void) InterfaceID;
     (void) searchIndex;

--- a/mDNSPosix/Makefile
+++ b/mDNSPosix/Makefile
@@ -37,7 +37,13 @@
 
 #############################################################################
 
-LIBVERS = 1
+
+
+LIB_MAJOR_VER = 1
+LIB_MINOR_VER = 0
+LIB_PATCH_VER = 0
+LIBVERS = $(LIB_MAJOR_VER).$(LIB_MINOR_VER).$(LIB_PATCH_VER)
+
 
 COREDIR = ../mDNSCore
 SHAREDDIR ?= ../mDNSShared
@@ -53,18 +59,24 @@ else ifeq ($(SYSTEM), Linux)
   os=linux
 endif
 
-CC = cc
+ifneq ($(findstring $(os),solaris x),)
+CC ?= gcc
+LD ?= gcc
+else
+CC ?= cc
+LD ?= ld
+endif
+
 BISON = bison
 FLEX = flex
-ST = strip
-LD = ld
+STRIP ?= strip
 SOOPTS = -shared
 CP = cp
 RM = rm
 LN = ln -s -f
 CFLAGS_COMMON = -I$(COREDIR) -I$(SHAREDDIR) -I$(UTILDIR) -I$(DSODIR) -I$(SERVICEREGISTRATIONDIR) -I$(OBJDIR) -fwrapv -W -Wall -DPOSIX_BUILD -DPID_FILE=\"/var/run/mdnsd.pid\" -DMDNS_UDS_SERVERPATH=\"/var/run/mdnsd\"
 CFLAGS_PTHREAD =
-LINKOPTS =
+LINKOPTS += ${LDFLAGS}
 LINKOPTS_PTHREAD = -lpthread
 LDSUFFIX = so
 JAVACFLAGS_OS = -fPIC -shared -ldns_sd
@@ -78,13 +90,13 @@ ifeq "$(DEBUG)" "1"
 CFLAGS_DEBUGGING = -g -DMDNS_DEBUGMSGS=2
 OBJDIR = objects/debug
 BUILDDIR = build/debug
-STRIP = echo
+MDNS_STRIP = echo
 else
 ifeq "$(DEBUGSYMS)" "1"
 CFLAGS_DEBUGGING = -g -DMDNS_DEBUGMSGS=0
 OBJDIR = objects/prod
 BUILDDIR = build/prod
-STRIP = echo
+MDNS_STRIP = echo
 else
 # We use -Os for two reasons:
 # 1. We want to make small binaries, suitable for putting into hardware devices
@@ -92,7 +104,7 @@ else
 CFLAGS_DEBUGGING = -g -DMDNS_DEBUGMSGS=0
 OBJDIR ?= objects/prod
 BUILDDIR ?= build/prod
-STRIP = $(ST) -S
+MDNS_STRIP = $(STRIP) -S
 endif
 endif
 
@@ -101,13 +113,11 @@ ifeq ($(os),solaris)
 CFLAGS_DEBUGGING = -O0 -DMDNS_DEBUGMSGS=0
 CFLAGS_OS = -DNOT_HAVE_DAEMON -DNOT_HAVE_SA_LEN -DNOT_HAVE_SOCKLEN_T -DNOT_HAVE_IF_NAMETOINDEX \
 	 -DLOG_PERROR=0 -D_XPG4_2 -D__EXTENSIONS__ -DHAVE_BROKEN_RECVIF_NAME -DTARGET_OS_SOLARIS
-CC = gcc
-LD = gcc
 SOOPTS = -shared
-LINKOPTS = -lsocket -lnsl -lresolv
+LINKOPTS += -lsocket -lnsl -lresolv
 JAVACFLAGS_OS += -I$(JDK)/include/solaris
 ifneq ($(DEBUG),1)
-STRIP = $(ST)
+MDNS_STRIP = $(STRIP)
 endif
 else
 
@@ -166,10 +176,9 @@ CFLAGS_OS = -DHAVE_IPV6 -no-cpp-precomp -Werror -Wdeclaration-after-statement \
 	-D__MAC_OS_X_VERSION_MIN_REQUIRED=__MAC_OS_X_VERSION_10_4 \
 	-DHAVE_STRLCPY=1 -DTARGET_OS_MAC \
 	-D__APPLE_USE_RFC_2292 #-Wunreachable-code
-CC = gcc
 LD = $(CC)
 SOOPTS = -dynamiclib
-LINKOPTS = -lSystem
+LINKOPTS += -lSystem
 LDSUFFIX = dylib
 JDK = /System/Library/Frameworks/JavaVM.framework/Home
 JAVACFLAGS_OS = -dynamiclib -I/System/Library/Frameworks/JavaVM.framework/Headers -framework JavaVM
@@ -233,7 +242,7 @@ endif
 endif
 endif
 
-MDNSCFLAGS = $(CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_OS) $(CFLAGS_DEBUGGING)
+MDNSCFLAGS = $(CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_OS) $(CFLAGS_DEBUGGING) $(CPPFLAGS) $(CXXFLAGS)
 
 #############################################################################
 
@@ -271,7 +280,7 @@ Daemon: setup $(BUILDDIR)/mdnsd
 
 $(BUILDDIR)/mdnsd: $(DAEMONOBJS)
 	$(CC) -o $@ $+ $(LINKOPTS)
-	$(STRIP) $@
+	$(MDNS_STRIP) $@
 
 # libdns_sd target builds the client library
 libdns_sd: setup $(BUILDDIR)/libdns_sd.$(LDSUFFIX)
@@ -280,8 +289,8 @@ libdns_sd: setup $(BUILDDIR)/libdns_sd.$(LDSUFFIX)
 CLIENTLIBOBJS = $(OBJDIR)/dnssd_clientlib.c.so.o $(OBJDIR)/dnssd_clientstub.c.so.o $(OBJDIR)/dnssd_ipc.c.so.o $(OBJDIR)/dnssd_errstring.c.so.o
 
 $(BUILDDIR)/libdns_sd.$(LDSUFFIX): $(CLIENTLIBOBJS)
-	$(LD) $(SOOPTS) $(LINKOPTS) -o $@ $+
-	$(STRIP) $@
+	$(LD) $(SOOPTS) $(LINKOPTS) -Wl,-soname,libdns_sd.$(LDSUFFIX).$(LIB_MAJOR_VER) -o $@ $+
+	$(MDNS_STRIP) $@
 
 Clients: setup libdns_sd ../Clients/build/dns-sd
 	@echo "Clients done"
@@ -295,7 +304,7 @@ nss_mdns: setup $(BUILDDIR)/$(NSSLIBFILE)
 
 $(BUILDDIR)/$(NSSLIBFILE): $(CLIENTLIBOBJS) $(OBJDIR)/nss_mdns.c.so.o
 	$(LD) $(SOOPTS) $(LINKOPTS) -o $@ $+
-	$(STRIP) $@
+	$(MDNS_STRIP) $@
 
 #############################################################################
 
@@ -326,7 +335,8 @@ $(INSTBASE)/sbin/mdnsd: $(BUILDDIR)/mdnsd $(STARTUPSCRIPTDIR)/$(STARTUPSCRIPTNAM
 
 $(INSTBASE)/lib/libdns_sd.$(LDSUFFIX).$(LIBVERS): $(BUILDDIR)/libdns_sd.$(LDSUFFIX)
 	$(CP) $< $@
-	$(LN) $@ $(INSTBASE)/lib/libdns_sd.$(LDSUFFIX)
+	$(LN) libdns_sd.$(LDSUFFIX).$(LIBVERS) $(INSTBASE)/lib/libdns_sd.$(LDSUFFIX).$(LIB_MAJOR_VER)
+	$(LN) libdns_sd.$(LDSUFFIX).$(LIB_MAJOR_VER) $(INSTBASE)/lib/libdns_sd.$(LDSUFFIX)
 ifdef LDCONFIG
 	# -m means 'merge into existing database', -R means 'rescan directories'
 	$(LDCONFIG) -mR

--- a/mDNSPosix/Makefile
+++ b/mDNSPosix/Makefile
@@ -69,6 +69,10 @@ LINKOPTS_PTHREAD = -lpthread
 LDSUFFIX = so
 JAVACFLAGS_OS = -fPIC -shared -ldns_sd
 
+ifeq ($(unicast_disabled), y)
+CFLAGS_COMMON += -DUNICAST_DISABLED
+endif
+
 # Set up diverging paths for debug vs. prod builds
 ifeq "$(DEBUG)" "1"
 CFLAGS_DEBUGGING = -g -DMDNS_DEBUGMSGS=2

--- a/mDNSPosix/Responder.c
+++ b/mDNSPosix/Responder.c
@@ -632,10 +632,13 @@ static mStatus RegisterOurServices(void)
 static void DeregisterOurServices(void)
 {
     PosixService *thisServ;
+    int thisServID;
 
     while (gServiceList != NULL) {
         thisServ = gServiceList;
         gServiceList = thisServ->next;
+
+        thisServID = thisServ->serviceID;
 
         mDNS_DeregisterService(&mDNSStorage, &thisServ->coreServ);
 
@@ -643,7 +646,7 @@ static void DeregisterOurServices(void)
             fprintf(stderr,
                     "%s: Deregistered service %d\n",
                     gProgramName,
-                    thisServ->serviceID);
+                    thisServID);
         }
     }
 }

--- a/mDNSPosix/mDNSPosix.c
+++ b/mDNSPosix/mDNSPosix.c
@@ -20,6 +20,7 @@
 #include "DNSCommon.h"
 #include "mDNSPosix.h"               // Defines the specific types needed to run mDNS on this platform
 #include "PlatformCommon.h"
+#include "uds_daemon.h"
 #include "dns_sd.h"
 
 #include <assert.h>
@@ -159,6 +160,19 @@ mDNSlocal void SockAddrTomDNSAddr(const struct sockaddr *const sa, mDNSAddr *ipA
 #pragma mark ***** Send and Receive
 #endif
 
+mDNSlocal PosixNetworkInterface *IfindexToInterfaceInfoPosix(mDNSInterfaceID InterfaceID)
+{
+    mDNS *const m = &mDNSStorage;
+    mDNSu32 ifindex = (mDNSu32)(uintptr_t)InterfaceID;
+    PosixNetworkInterface *intf;
+
+    intf = (PosixNetworkInterface*)(m->HostInterfaces);
+    while ((intf != NULL) && (mDNSu32) intf->index != ifindex)
+        intf = (PosixNetworkInterface *)(intf->coreIntf.next);
+
+    return intf ? intf->aliasIntf : mDNSNULL;
+}
+
 // mDNS core calls this routine when it needs to send a packet.
 mDNSexport mStatus mDNSPlatformSendUDP(const mDNS *const m, const void *const msg, const mDNSu8 *const end,
                                        mDNSInterfaceID InterfaceID, UDPSocket *src, const mDNSAddr *dst,
@@ -166,7 +180,7 @@ mDNSexport mStatus mDNSPlatformSendUDP(const mDNS *const m, const void *const ms
 {
     int err = 0;
     struct sockaddr_storage to;
-    PosixNetworkInterface * thisIntf = (PosixNetworkInterface *)(InterfaceID);
+    PosixNetworkInterface * thisIntf;
     int sendingsocket = -1;
     struct sockaddr *sa = (struct sockaddr *)&to;
 
@@ -176,6 +190,13 @@ mDNSexport mStatus mDNSPlatformSendUDP(const mDNS *const m, const void *const ms
     assert(msg != NULL);
     assert(end != NULL);
     assert((((char *) end) - ((char *) msg)) > 0);
+
+    thisIntf = IfindexToInterfaceInfoPosix(InterfaceID);
+    if (thisIntf == NULL)
+    {
+        LogMsg("mDNSPlatformSendUDP: Invalid argument -interface index is set to %p", InterfaceID);
+        return mStatus_BadParamErr;
+    }
 
     if (dstPort.NotAnInteger == 0)
     {
@@ -652,9 +673,9 @@ mDNSexport mStatus mDNSPlatformTCPConnect(TCPSocket *sock, const mDNSAddr *dst, 
     }
 
     // If we've been asked to bind to a single interface, do it.  See comment in mDNSMacOSX.c for more info.
-    if (InterfaceID)
+    PosixNetworkInterface *iface = IfindexToInterfaceInfoPosix(InterfaceID);
+    if (iface)
     {
-        PosixNetworkInterface *iface = (PosixNetworkInterface *)InterfaceID;
 #if defined(SO_BINDTODEVICE)
         result = setsockopt(sock->events.fd,
                             SOL_SOCKET, SO_BINDTODEVICE, iface->intfName, strlen(iface->intfName));
@@ -989,7 +1010,7 @@ mDNSexport mDNSInterfaceID mDNSPlatformInterfaceIDfromInterfaceIndex(mDNS *const
     while ((intf != NULL) && (mDNSu32) intf->index != index)
         intf = (PosixNetworkInterface *)(intf->coreIntf.next);
 
-    return (mDNSInterfaceID) intf;
+    return intf ? intf->coreIntf.InterfaceID : mDNSNULL;
 }
 
 mDNSexport mDNSu32 mDNSPlatformInterfaceIndexfromInterfaceID(mDNS *const m, mDNSInterfaceID id, mDNSBool suppressNetworkChange)
@@ -1004,14 +1025,14 @@ mDNSexport mDNSu32 mDNSPlatformInterfaceIndexfromInterfaceID(mDNS *const m, mDNS
     if (id == mDNSInterface_Any      ) return(kDNSServiceInterfaceIndexAny);
 
     intf = (PosixNetworkInterface*)(m->HostInterfaces);
-    while ((intf != NULL) && (mDNSInterfaceID) intf != id)
+    while ((intf != NULL) && intf->coreIntf.InterfaceID != id)
         intf = (PosixNetworkInterface *)(intf->coreIntf.next);
 
     if (intf) return intf->index;
 
     // If we didn't find the interface, check the RecentInterfaces list as well
     intf = gRecentInterfaces;
-    while ((intf != NULL) && (mDNSInterfaceID) intf != id)
+    while ((intf != NULL) && intf->coreIntf.InterfaceID != id)
         intf = (PosixNetworkInterface *)(intf->coreIntf.next);
 
     return intf ? intf->index : 0;
@@ -1398,7 +1419,8 @@ mDNSlocal int SetupOneInterface(mDNS *const m, struct sockaddr *intfAddr, struct
 #endif
         alias                      = SearchForInterfaceByName(m, intf->intfName);
         if (alias == NULL) alias   = intf;
-        intf->coreIntf.InterfaceID = (mDNSInterfaceID)alias;
+        intf->coreIntf.InterfaceID = (mDNSInterfaceID)(uintptr_t)alias->index;
+        intf->aliasIntf = alias;
 
         if (alias != intf)
             debugf("SetupOneInterface: %s %#a is an alias of %#a", intfName, &intf->coreIntf.ip, &alias->coreIntf.ip);

--- a/mDNSPosix/mDNSPosix.h
+++ b/mDNSPosix/mDNSPosix.h
@@ -51,6 +51,7 @@ extern int gMDNSPlatformPosixVerboseLevel;
 
 struct mDNS_PlatformSupport_struct
 {
+    void* intfChg;
     int unicastSocket4;
 #if HAVE_IPV6
     int unicastSocket6;

--- a/mDNSPosix/mbedtls.c
+++ b/mDNSPosix/mbedtls.c
@@ -218,10 +218,12 @@ mDNSPosixTLSRead(TCPSocket *sock, void *buf, unsigned long buflen, mDNSBool *clo
             // and then re-enable read events.   What we don't want is to keep calling
             // read, because that will spin.
             return 0;
+#ifdef MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS
         case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
             LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_ERROR, "Got async in progress in TLS read!");
             // No idea how to handle this yet.
             return 0;
+#endif
 #ifdef MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS
         case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS:
             LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_ERROR, "Got crypto in progress in TLS read!");
@@ -259,9 +261,11 @@ mDNSPosixTLSWrite(TCPSocket *sock, const void *buf, unsigned long buflen)
         case MBEDTLS_ERR_SSL_WANT_WRITE:
             LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_ERROR, "Got SSL want write in TLS read!");
             return 0;
+#ifdef MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS
         case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
             LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_ERROR, "Got async in progress in TLS read!");
             return 0;
+#endif
 #ifdef MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS
         case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS:
             LogRedact(MDNS_LOG_CATEGORY_DEFAULT, MDNS_LOG_ERROR, "Got crypto in progress in TLS read!");

--- a/mDNSShared/dnsextd.c
+++ b/mDNSShared/dnsextd.c
@@ -3101,6 +3101,7 @@ DNSServer *mDNS_AddDNSServer(mDNS *const m, const domainname *d, const mDNSInter
                              mDNSu32 scopedType, mDNSu32 timeout, mDNSBool isCell, mDNSBool isExpensive, mDNSBool isConstrained,  mDNSBool isCLAT46, mDNSu32 resGroupID, mDNSBool reqA, mDNSBool reqAAAA, mDNSBool reqDO)
 { ( void ) m; ( void ) d; ( void ) interface; ( void ) serviceID; ( void ) addr; ( void ) port; ( void ) scopedType; ( void ) timeout; (void) isCell; (void) isExpensive; (void) isConstrained; (void) isCLAT46;
     (void) resGroupID; (void) reqA; (void) reqAAAA; (void) reqDO; return(NULL); }
+void mDNS_ClearDNSServers(mDNS *const m) { (void) m;}
 void mDNS_AddSearchDomain(const domainname *const domain, mDNSInterfaceID InterfaceID) { (void)domain; (void) InterfaceID;}
 void mDNS_AddDynDNSHostName(mDNS *m, const domainname *fqdn, mDNSRecordCallback *StatusCallback, const void *StatusContext)
 { ( void ) m; ( void ) fqdn; ( void ) StatusCallback; ( void ) StatusContext; }

--- a/mDNSShared/uds_daemon.c
+++ b/mDNSShared/uds_daemon.c
@@ -2913,7 +2913,11 @@ exit:
 mDNSlocal mStatus add_domain_to_browser(request_state *info, const domainname *d)
 {
     browser_t *b, *p;
+#if MDNSRESPONDER_PLATFORM_APPLE
     __block mStatus err;
+#else
+    mStatus err;
+#endif
 
     for (p = info->u.browser.browsers; p; p = p->next)
     {

--- a/mDNSShared/uds_daemon.c
+++ b/mDNSShared/uds_daemon.c
@@ -28,6 +28,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "mDNSEmbeddedAPI.h"
 #include "DNSCommon.h"
@@ -104,6 +105,7 @@ static char* boundPath = NULL;
 #else
 static char* boundPath = MDNS_UDS_SERVERPATH;
 #endif
+static char udsServerPath[128] = {0};
 #if DEBUG
 #define MDNS_UDS_SERVERPATH_DEBUG "/var/tmp/mDNSResponder"
 #endif
@@ -5903,6 +5905,12 @@ mDNSexport int udsserver_init(dnssd_sock_t skts[], const size_t count)
         #else
         {
             mode_t mask = umask(0);
+            char* uds_serverpath = getenv(MDNS_UDS_SERVERPATH_ENVVAR);
+            if (uds_serverpath != NULL && strlen(uds_serverpath) < sizeof(udsServerPath))
+            {
+                strcpy(udsServerPath, uds_serverpath);
+                boundPath = udsServerPath;
+            }
             unlink(boundPath);  // OK if this fails
             laddr.sun_family = AF_LOCAL;
             #ifndef NOT_HAVE_SA_LEN


### PR DESCRIPTION
1.Resolve compile errors on linux platform.

2.Resolve the problem that services cannot be discovered after network interface restart.( I found that If the interface restart,   the interface object will be change(the interface index remains the same), which will result in services previously bound to the interface's mDNSInterfaceID will not being discovered again)
https://github.com/apple-oss-distributions/mDNSResponder/blob/rel/mDNSResponder-1790/mDNSCore/mDNS.c#L15414
https://github.com/apple-oss-distributions/mDNSResponder/blob/rel/mDNSResponder-1790/mDNSPosix/mDNSPosix.c#L1401

3.Resolve memory leak.

4.Add unicast-disable compile option.

5.Add uds-server path environment variable.

6.Support cross building on linux platform.

